### PR TITLE
Add error logic into `main.handlebars`

### DIFF
--- a/server/views/layouts/main.handlebars
+++ b/server/views/layouts/main.handlebars
@@ -9,6 +9,15 @@
 </head>
 
 <body>
+  {{#if errors}}
+  <div class="error-container">
+    <ul>
+      {{#each errors}}
+      <li>{{this}}</li>
+      {{/each}}
+    </ul>
+  </div>
+  {{/if}}
   {{{body}}}
 </body>
 


### PR DESCRIPTION
This PR will allow our pages to display errors via the main template rather
than having to implement logic for displaying errors page by page.
